### PR TITLE
Reuse the EXIF data if the images look close together

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,1 +1,4 @@
 brew 'libexif'
+
+tap 'eddieantonio/eddieantonio'
+brew 'imgcat'

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
+gem 'byebug'
 gem 'exif'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,15 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    exifr (1.3.2)
+    byebug (10.0.1)
+    exif (2.2.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  exifr
+  byebug
+  exif
 
 BUNDLED WITH
-   1.14.6
+   1.16.0

--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# photo-unfucker
+
+Importing photos sucks. I used to use iPhoto, which does dupe detection, organizes by exif dates and all sorts of other things.
+
+Apple can go fuck theirselves. iPhotos is salty garbage. Using iPhotos on a network share is just downright ludicrous. 
+
+Instead, this dodgy little (completely untested) ruby script is clearly more trustworthy. 
+
+## Setup 
+
+```
+# Install brew stuff
+brew bundle
+
+# Install ruby stuff
+bundle install
+```
+
+## Usage
+
+Point it at a folder full of your pictures like this but READ THE WHOLE README BEFORE YOU RUN THIS OR SO HELP ME!
+
+``` shell
+IMPORT_PATH=/Users/psturgeon/Pictures/import/ ruby rename.rb
+```
+
+This will **move files out of the import folder** (using actual `mv`) and into a new structure like this:
+
+```
+2018/2018-12/2018-12-01 23:59:59.jpg
+```
+
+The output folder will be `./export` unless you provide `EXPORT_PATH` too.
+
+It has duplicate detection with checksums, and it'll even try to help you out when EXIF dates are missing:
+
+![](https://user-images.githubusercontent.com/67381/38002713-d6aa89fa-3201-11e8-9ca2-622d218d3e8b.png)
+
+![](https://user-images.githubusercontent.com/67381/38002700-c3df292a-3201-11e8-9c03-9e10731e1b16.png)
+
+This probably only works on OSX, who knows. 👋🏻

--- a/rename.rb
+++ b/rename.rb
@@ -19,9 +19,11 @@ puts "Scanning #{importFolder}"
 
 i = 0
 
+# These will be updated as we go
+previous_data = previous_filepath = nil
+
 Dir.glob("#{importFolder}/**/*.{jpg,jpeg,JPG,JPEG}") do |filepath|
   i += 1
-  # exit if i > 1000
 
   puts "\nLoading #{filepath}"
 
@@ -29,18 +31,41 @@ Dir.glob("#{importFolder}/**/*.{jpg,jpeg,JPG,JPEG}") do |filepath|
 
   begin
     data = Exif::Data.new(file)
-  rescue Exif::NotReadble
-
-    puts file
-    exit
-
-    puts "Skipping: Could not read EXIF data for #{filepath}"
+  rescue Exif::NotReadable
+    puts "Skipping: Could not read EXIF data for \"#{filepath}\""
     next
   end
 
   if !data.date_time
-    puts "Skipping: Couldn't find the date time"
-    next
+
+    if !previous_filepath
+      puts "Skipping: Couldn't find the date time"
+      next
+    end
+
+    puts "Missing EXIF data, lets try this another way... \n\n"
+    system "imgcat \"#{previous_filepath}\""
+    puts "...aaaand..."
+    system "imgcat \"#{filepath}\""
+
+    puts "Does it look like these two photos are relevatively close together chronolocically? Or should we just delete the one at the bottom? [Y/n/s/d]"
+
+    answer = STDIN.gets.strip.downcase
+    if answer == "d"
+      puts "Deleting photo entirely. Screw that shitty photo."
+      system 'rm', filepath
+      next
+
+    elsif answer == "y"
+      puts "answered! #{answer}"
+      data = previous_data
+
+    else
+      # Clearly we've moved on in time
+      previous_data = previous_filepath = nil
+      puts "Skipping: Meh entering a date here would be annoying so just figure it out yourself"
+      next
+    end
   end
 
   date_time = DateTime.strptime(data.date_time, '%Y:%m:%d %H:%M:%S')
@@ -48,13 +73,27 @@ Dir.glob("#{importFolder}/**/*.{jpg,jpeg,JPG,JPEG}") do |filepath|
   folder = date_time.strftime('%Y/%Y-%m')
   dest_basename = date_time.strftime('%Y-%m-%d %H-%M-%S')
   dest_path = "#{exportFolder}/#{folder}"
-
-  # TODO MAAAYBE we need some second duplicate avoidance
-  # dest_count = `ls -1 #{dest_path} | wc -l`.to_i
-  # dest_filepath = "#{dest_path}/#{dest_basename} - #{dest_count}.jpg"
   dest_filepath = "#{dest_path}/#{dest_basename}.jpg"
+
+  # Uh oh, duplicate file!
+  if File.exists?(dest_filepath)
+    puts "Duplicate file name for #{dest_filepath}"
+
+    if `md5 -q "#{filepath}"` === `md5 -q "#{dest_filepath}"`
+      puts "Skipping, source and destination md5 signatures match"
+    else
+      dir = File.dirname(dest_filepath)
+      ext = File.extname(dest_filepath)
+      dest_filepath = "#{dir}/#{File.basename(dest_filepath, ext)}-#{i}#{ext}"
+
+      puts "Giving new name #{dest_filepath}"
+    end
+  end
 
   puts "Moving to #{dest_filepath}"
   system 'mkdir', '-p', "#{dest_path}" unless File.exists?("#{dest_path}")
   system 'mv', filepath, dest_filepath
+
+  previous_filepath = dest_filepath
+  previous_data = data
 end


### PR DESCRIPTION
Insted of just skipping things without EXIF dates, try asking the user if the thing happened at a close enough time to just go with that old date. Duplicate logic will then kick in and append `-#{i}` so it's all good.

<img width="709" alt="screen shot 2018-03-27 at 8 59 54 pm" src="https://user-images.githubusercontent.com/67381/38002713-d6aa89fa-3201-11e8-9ca2-622d218d3e8b.png">

<img width="1020" alt="screen shot 2018-03-27 at 8 55 06 pm" src="https://user-images.githubusercontent.com/67381/38002700-c3df292a-3201-11e8-9c03-9e10731e1b16.png">

Also im just testing this in production with my own photos lol who needs memories. 